### PR TITLE
Spi master implementation

### DIFF
--- a/src/hdl/spi_master_mock.v
+++ b/src/hdl/spi_master_mock.v
@@ -11,6 +11,7 @@
 // Description: Mock-up ESP32 SPI Master designed to simulate the micrcontroller
 //              SPI master behavior used to validate actually synthesizeable
 //              FPGA SPI slave.
+//              Module configured for SPI Mode 0.
 //
 // Dependencies: params.vh
 //
@@ -24,23 +25,113 @@
 
 
 module spi_master_mock (
-    input                                 sclk,
-    input  wire [`MASTER_FRAME_WIDTH-1:0] i_frame, // input data frame- its creation is done outside of the module
-    input  wire [`BRIGHTNESS_WIDTH:0]     miso,    // read input from slave
-    output wire                           cs,      // chip select (active low)
-    output reg                            mclk,    // clock signal issued to slave
-    output reg                            mosi,    // serial master output
+    input                                 sysclk,
+    input  wire                           tx_enb,      // high active for data frame ready to send
+    input  wire [`MASTER_FRAME_WIDTH-1:0] i_frame,     // input data frame- its creation is done outside of the module
+    input  wire                           miso,        // read input from slave
+    output reg                            cs,          // chip select (active low)
+    output wire                           sclk,        // clock signal issued to slave
+    output reg                            mosi,        // serial master output
+    output wire [`BRIGHTNESS_WIDTH:0]     o_frame      // entire response
 );
 
     // SPI Master FSM
-    localparam IDLE    3'b000; // on transition from IDLE to COMMAND cs is asserted
-    localparam COMMAND 3'b001;
-    localparam ADDRESS 3'b010;
-    localparam READ    3'b100;
-    localparam WRITE   3'b110;
-    localparam DONE    3'b111; // deasserts cs
+    localparam                    IDLE       3'b000;   // on transition from IDLE to COMMAND cs is asserted
+    localparam                    COMMAND    3'b001;
+    localparam                    ADDRESS    3'b010;
+    // localparam                    READ       3'b100;
+    localparam                    WRITE      3'b110;
+    localparam                    DONE       3'b111;   // deasserts cs
 
-    reg [2:0]  curr_state;
+    // Master transmitter + sclk generation
+    reg [2:0]                     curr_state;
+    reg [4:0]                     bit_frame_cnt;       // indexing what is the current bit from data frame to send
+    reg                           sclk_int;            // internal output master clock
+    reg [2:0]                     sclk_cnt   = 0;      // count cycles of 125Mhz frequency clock before issuing sclk pulse
+    reg [`MASTER_FRAME_WIDTH-1:0] shift_reg_tx;        // transmit shift register
 
+    // Master receiver
+    reg [2:0]                     bit_rx_cnt = 0;
+    reg [`MASTER_FRAME_WIDTH-1:0] shift_reg_rx = 0;    // receive shift register
+
+    // 26MHz pulse generator
+    always (posedge sysclk) begin
+        if (sclk_cnt == (`CLKS_PER_MASTER_SCLK - 1)) begin
+            sclk_int <= 1'b1;
+            sclk_cnt <= 0;
+        end else begin
+            sclk_int <= 1'b0;
+            sclk_cnt <= sclk_cnt + 1'b1;
+        end
+    end
+    assign sclk = sclk_int;
+
+    // Write process
+    always (posedge sysclk) begin 
+        case (curr_state)
+            IDLE   : begin
+                cs               <= `CS_DEASSERT;
+                bit_frame_cnt    <= 0;
+                mosi             <= 1'bx;
+                shift_reg_tx     <= 0;
+                if (tx_enb == 1'b1) begin
+                    shift_reg_tx <= i_frame;
+                    cs           <= `CS_ASSERT;
+                    curr_state   <= COMMAND;
+                end
+            end
+            COMMAND: begin
+                if (sclk_int == 1'b1 && bit_frame_cnt <= (`CMD_BITS - 1)) begin
+                    mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
+                    shift_reg_tx  <= shift_reg_tx << 1;
+                    bit_frame_cnt <= bit_frame_cnt + 1'b1;
+                end else if (bit_frame_cnt == `CMD_BITS) begin
+                    bit_frame_cnt <= 0;
+                    curr_state    <= ADDRESS;
+                end
+            end
+            ADDRESS: begin
+                if (sclk_int == 1'b1 && bit_frame_cnt <= (`ADDR_BITS - 1)) begin
+                    mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
+                    shift_reg_tx  <= shift_reg_tx << 1;
+                    bit_frame_cnt <= bit_frame_cnt + 1'b1;
+                end else if (bit_frame_cnt == `ADDR_BITS) begin
+                    bit_frame_cnt <= 0;
+                    curr_state    <= ADDRESS;
+                end
+            end
+            WRITE  : begin
+                if (sclk_int == 1'b1 && bit_frame_cnt <= (`PAYLOAD_BITS - 1)) begin
+                    mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
+                    shift_reg_tx  <= shift_reg_tx << 1;
+                    bit_frame_cnt <= bit_frame_cnt + 1'b1;
+                end else if (bit_frame_cnt == `PAYLOAD_BITS) begin
+                    bit_frame_cnt <= 0;
+                    curr_state    <= DONE;
+                end
+            end
+            DONE   : begin
+                cs            <= `CS_DEASSERT;
+                mosi          <= 1'bx;
+                bit_frame_cnt <= 0;
+                shift_reg_tx  <= 0;
+                curr_state    <= IDLE;
+            end
+            default: curr_state <= IDLE;
+        endcase
+    end
+
+    // Read process
+    always (posedge sysclk) begin
+        if (sclk_int == 1'b1 && bit_rx_cnt <= (`PAYLOAD_BITS - 1)) begin
+            shift_reg_rx[bit_rx_cnt] <= miso;
+            shift_reg_rx             <= shift_reg_rx << 1;
+            bit_rx_cnt               <= bit_rx_cnt + 1'b1;
+        end else if (bit_rx_cnt == `PAYLOAD_BITS) begin
+            bit_frame_cnt <= 0;
+            shift_reg_rx  <= 0;
+        end
+    end
+    assign o_frame = shift_reg_rx;
 
 endmodule

--- a/src/hdl/spi_master_mock.v
+++ b/src/hdl/spi_master_mock.v
@@ -1,0 +1,32 @@
+//////////////////////////////////////////////////////////////////////////////////
+// Company: ISAE
+// Engineer: Szymon Bogus
+//
+// Create Date: 24/07/2025
+// Design Name:
+// Module Name: spi_master_mock
+// Project Name: simple-spi
+// Target Devices: Zybo Z7-20
+// Tool Versions:
+// Description: Mock-up ESP32 SPI Master designed to simulate the micrcontroller
+//              SPI master behavior used to validate actually synthesizeable
+//              FPGA SPI slave.
+//
+// Dependencies: params.vh
+//
+// Revision:
+// Revision 0.01 - File Created
+// Additional Comments:
+//
+//////////////////////////////////////////////////////////////////////////////////
+`timescale 1ns/1ps
+`include "../include/params.vh"
+
+
+module spi_master_mock (
+
+);
+
+
+
+endmodule

--- a/src/hdl/spi_master_mock.v
+++ b/src/hdl/spi_master_mock.v
@@ -97,7 +97,7 @@ module spi_master_mock (
                     bit_frame_cnt <= bit_frame_cnt + 1'b1;
                 end else if (bit_frame_cnt == `ADDR_BITS) begin
                     bit_frame_cnt <= 0;
-                    curr_state    <= ADDRESS;
+                    curr_state    <= WRITE;
                 end
             end
             WRITE  : begin

--- a/src/hdl/spi_master_mock.v
+++ b/src/hdl/spi_master_mock.v
@@ -81,6 +81,7 @@ module spi_master_mock (
                 end
             end
             COMMAND: begin
+                cs                <= `CS_ASSERT;
                 if (sclk_int == 1'b1 && bit_frame_cnt <= (`CMD_BITS - 1)) begin
                     mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
                     shift_reg_tx  <= shift_reg_tx << 1;
@@ -91,6 +92,7 @@ module spi_master_mock (
                 end
             end
             ADDRESS: begin
+                cs                <= `CS_ASSERT;
                 if (sclk_int == 1'b1 && bit_frame_cnt <= (`ADDR_BITS - 1)) begin
                     mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
                     shift_reg_tx  <= shift_reg_tx << 1;
@@ -101,6 +103,7 @@ module spi_master_mock (
                 end
             end
             WRITE  : begin
+                cs                <= `CS_ASSERT;
                 if (sclk_int == 1'b1 && bit_frame_cnt <= (`PAYLOAD_BITS - 1)) begin
                     mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
                     shift_reg_tx  <= shift_reg_tx << 1;

--- a/src/hdl/spi_master_mock.v
+++ b/src/hdl/spi_master_mock.v
@@ -47,11 +47,11 @@ module spi_master_mock (
     reg [2:0]                     curr_state;
     reg [4:0]                     bit_frame_cnt;       // indexing what is the current bit from data frame to send
     reg                           sclk_int;            // internal output master clock
-    reg [2:0]                     sclk_cnt   = 0;      // count cycles of 125Mhz frequency clock before issuing sclk pulse
+    reg [2:0]                     sclk_cnt     = 0;    // count cycles of 125Mhz frequency clock before issuing sclk pulse
     reg [`MASTER_FRAME_WIDTH-1:0] shift_reg_tx;        // transmit shift register
 
     // Master receiver
-    reg [2:0]                     bit_rx_cnt = 0;
+    reg [2:0]                     bit_rx_cnt   = 0;
     reg [`MASTER_FRAME_WIDTH-1:0] shift_reg_rx = 0;    // receive shift register
 
     // 26MHz pulse generator

--- a/src/hdl/spi_master_mock.v
+++ b/src/hdl/spi_master_mock.v
@@ -36,12 +36,12 @@ module spi_master_mock (
 );
 
     // SPI Master FSM
-    localparam                    IDLE       3'b000;   // on transition from IDLE to COMMAND cs is asserted
-    localparam                    COMMAND    3'b001;
-    localparam                    ADDRESS    3'b010;
-    // localparam                    READ       3'b100;
-    localparam                    WRITE      3'b110;
-    localparam                    DONE       3'b111;   // deasserts cs
+    localparam                    IDLE       = 3'b000;   // on transition from IDLE to COMMAND cs is asserted
+    localparam                    COMMAND    = 3'b001;
+    localparam                    ADDRESS    = 3'b010;
+    // localparam                    READ       = 3'b100;
+    localparam                    WRITE      = 3'b110;
+    localparam                    DONE       = 3'b111;   // deasserts cs
 
     // Master transmitter + sclk generation
     reg [2:0]                     curr_state;
@@ -55,7 +55,7 @@ module spi_master_mock (
     reg [`MASTER_FRAME_WIDTH-1:0] shift_reg_rx = 0;    // receive shift register
 
     // 26MHz pulse generator
-    always (posedge sysclk) begin
+    always @(posedge sysclk) begin
         if (sclk_cnt == (`CLKS_PER_MASTER_SCLK - 1)) begin
             sclk_int <= 1'b1;
             sclk_cnt <= 0;
@@ -67,7 +67,7 @@ module spi_master_mock (
     assign sclk = sclk_int;
 
     // Write process: triggered on the falling edge sclk_int
-    always (posedge sysclk) begin 
+    always @(posedge sysclk) begin 
         case (curr_state)
             IDLE   : begin
                 cs               <= `CS_DEASSERT;
@@ -84,7 +84,7 @@ module spi_master_mock (
                 cs                <= `CS_ASSERT;
                 if (sclk_int && bit_frame_cnt <= (`CMD_BITS - 1)) begin
                     mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
-                    shift_reg_tx <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
+                    shift_reg_tx  <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
                     bit_frame_cnt <= bit_frame_cnt + 1'b1;
                 end else if (bit_frame_cnt == `CMD_BITS) begin
                     bit_frame_cnt <= 0;
@@ -95,7 +95,7 @@ module spi_master_mock (
                 cs                <= `CS_ASSERT;
                 if (sclk_int && bit_frame_cnt <= (`ADDR_BITS - 1)) begin
                     mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
-                    shift_reg_tx <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
+                    shift_reg_tx  <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
                     bit_frame_cnt <= bit_frame_cnt + 1'b1;
                 end else if (bit_frame_cnt == `ADDR_BITS) begin
                     bit_frame_cnt <= 0;
@@ -106,7 +106,7 @@ module spi_master_mock (
                 cs                <= `CS_ASSERT;
                 if (sclk_int && bit_frame_cnt <= (`PAYLOAD_BITS - 1)) begin
                     mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
-                    shift_reg_tx <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
+                    shift_reg_tx  <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
                     bit_frame_cnt <= bit_frame_cnt + 1'b1;
                 end else if (bit_frame_cnt == `PAYLOAD_BITS) begin
                     bit_frame_cnt <= 0;

--- a/src/hdl/spi_master_mock.v
+++ b/src/hdl/spi_master_mock.v
@@ -16,7 +16,7 @@
 //
 // Revision:
 // Revision 0.01 - File Created
-// Additional Comments:
+// Additional Comments: not synthesizeable, only for simulation
 //
 //////////////////////////////////////////////////////////////////////////////////
 `timescale 1ns/1ps
@@ -24,9 +24,23 @@
 
 
 module spi_master_mock (
-
+    input                                 sclk,
+    input  wire [`MASTER_FRAME_WIDTH-1:0] i_frame, // input data frame- its creation is done outside of the module
+    input  wire [`BRIGHTNESS_WIDTH:0]     miso,    // read input from slave
+    output wire                           cs,      // chip select (active low)
+    output reg                            mclk,    // clock signal issued to slave
+    output reg                            mosi,    // serial master output
 );
 
+    // SPI Master FSM
+    localparam IDLE    3'b000; // on transition from IDLE to COMMAND cs is asserted
+    localparam COMMAND 3'b001;
+    localparam ADDRESS 3'b010;
+    localparam READ    3'b100;
+    localparam WRITE   3'b110;
+    localparam DONE    3'b111; // deasserts cs
+
+    reg [2:0]  curr_state;
 
 
 endmodule

--- a/src/include/params.vh
+++ b/src/include/params.vh
@@ -2,12 +2,13 @@
 `define PARAMS_V
 
 // PWM (LED control)
-`define BRIGHTNESS_WIDTH   7  // brightness level can vary: 0%-100%; 7-bit number required to store the input value
-`define LED_MIN_BRIGHTNESS 0  // minimal level of brightness in %- min. duty cycle
-`define LED_MAX_BRIGHTNESS 90 // maximal level of brightness in %- max. duty cycle
+`define BRIGHTNESS_WIDTH   7    // brightness level can vary: 0%-100%; 7-bit number required to store the input value
+`define LED_MIN_BRIGHTNESS 0    // minimal level of brightness in %- min. duty cycle
+`define LED_MAX_BRIGHTNESS 90   // maximal level of brightness in %- max. duty cycle
 
 // Simulation
-`define CLK_NS             8 // 125MHz => 8ns
+`define SLAVE_CLK_NS       8    // 125MHz => 8ns | Frequency related to Xilinx Zynq 7020
+`define MASTER_CLK_NS      38.5 // 26MHz =? 38.5ns | Frequency of ESP32 SPI Master     
 
 
 `endif // PARAMS_V

--- a/src/include/params.vh
+++ b/src/include/params.vh
@@ -6,6 +6,9 @@
 `define LED_MIN_BRIGHTNESS 0    // minimal level of brightness in %- min. duty cycle
 `define LED_MAX_BRIGHTNESS 90   // maximal level of brightness in %- max. duty cycle
 
+// SPI data frame
+`define MASTER_FRAME_WIDTH 24   // 24 bits wide master data frame
+
 // Simulation
 `define SLAVE_CLK_NS       8    // 125MHz => 8ns | Frequency related to Xilinx Zynq 7020
 `define MASTER_CLK_NS      38.5 // 26MHz =? 38.5ns | Frequency of ESP32 SPI Master     

--- a/src/include/params.vh
+++ b/src/include/params.vh
@@ -2,16 +2,30 @@
 `define PARAMS_V
 
 // PWM (LED control)
-`define BRIGHTNESS_WIDTH   7    // brightness level can vary: 0%-100%; 7-bit number required to store the input value
-`define LED_MIN_BRIGHTNESS 0    // minimal level of brightness in %- min. duty cycle
-`define LED_MAX_BRIGHTNESS 90   // maximal level of brightness in %- max. duty cycle
+`define BRIGHTNESS_WIDTH     7    // brightness level can vary: 0%-100%; 7-bit number required to store the input value
+`define LED_MIN_BRIGHTNESS   0    // minimal level of brightness in %- min. duty cycle
+`define LED_MAX_BRIGHTNESS   90   // maximal level of brightness in %- max. duty cycle
 
+// SPI
 // SPI data frame
-`define MASTER_FRAME_WIDTH 24   // 24 bits wide master data frame
+`define MASTER_FRAME_WIDTH   24   // 24 bits wide master data frame
+`define CLKS_PER_MASTER_SCLK 5    // FPGA has 125Mhz clock but ESP32 SPI Master has 26MHz, this parameter specifies how many 
+                                  // 125Mhz frequency clock cycles to wait before issuing 25Mhz pulse
+
+// SPI Master data frame is 24 bits wide and each section: command, address, payload
+// is equally 8 bits wide, however, when the data for a section isn't encoded with 8 bits
+// but with n-bits then first n-bits are important and the rest is garbage
+`define CMD_BITS             8 // first 2 bits matter
+`define ADDR_BITS            8 // first 4 bits matter
+`define PAYLOAD_BITS         8 // first 7 bits matter | corresponds to payload of both master and slave
+
+// CS
+`define CS_ASSERT            1'b0
+`define CS_DEASSERT          1'b1
 
 // Simulation
-`define SLAVE_CLK_NS       8    // 125MHz => 8ns | Frequency related to Xilinx Zynq 7020
-`define MASTER_CLK_NS      38.5 // 26MHz =? 38.5ns | Frequency of ESP32 SPI Master     
+`define SLAVE_CLK_NS         8    // 125MHz => 8ns | Frequency related to Xilinx Zynq 7020
+`define MASTER_CLK_NS        38.5 // 26MHz =? 38.5ns | Frequency of ESP32 SPI Master     
 
 
 `endif // PARAMS_V

--- a/src/sim/pwm_tb.v
+++ b/src/sim/pwm_tb.v
@@ -44,7 +44,7 @@ module pwm_tb (
 
     initial begin
         clk = 0;
-        forever #(`CLK_NS/2) clk = ~clk; 
+        forever #(`SLAVE_CLK_NS/2) clk = ~clk; 
     end
 
     initial begin
@@ -59,7 +59,7 @@ module pwm_tb (
         // Reset condition
         i_enb = 1'b0;
         i_d   = 0;
-        #(`CLK_NS);
+        #(`SLAVE_CLK_NS);
 
         // Test 1: reseting pwm
         if (o_cnt == (2**`BRIGHTNESS_WIDTH - 1)) begin
@@ -77,12 +77,12 @@ module pwm_tb (
         // Test 2: duty cycle set to 25%
         i_enb = 1'b1;
         i_d   = 32; // 25% of 127
-        #(`CLK_NS * 2**`BRIGHTNESS_WIDTH);
+        #(`SLAVE_CLK_NS * 2**`BRIGHTNESS_WIDTH);
         $display("Test 2: inspect waveforms for o_pmw high for 32 clocks");
 
         // Test 3: duty cycle set to 0% (should output 0%)
         i_d = 0;
-        #(`CLK_NS * 2**`BRIGHTNESS_WIDTH); 
+        #(`SLAVE_CLK_NS * 2**`BRIGHTNESS_WIDTH); 
         if (o_pwm == 1'b0) begin
             $display("Test 3: PASS");
         end else begin
@@ -91,11 +91,11 @@ module pwm_tb (
 
         // Test 4: duty cycle set to 100% (should output 90%)
         i_d = 127; // 100% duty cycle
-        #(`CLK_NS * 2**`BRIGHTNESS_WIDTH);
+        #(`SLAVE_CLK_NS * 2**`BRIGHTNESS_WIDTH);
         $display("Test 4: inspect waveform for o_pwm high for 127 clocks");
 
         // End simulation
-        #(`CLK_NS * 5);
+        #(`SLAVE_CLK_NS * 5);
         $display("Simulation complete");
         $finish;
 

--- a/src/sim/spi_master_mock_tb.v
+++ b/src/sim/spi_master_mock_tb.v
@@ -1,0 +1,145 @@
+//////////////////////////////////////////////////////////////////////////////////
+// Company: ISAE
+// Engineer: Szymon Bogus
+//
+// Create Date: 24/07/2025
+// Design Name:
+// Module Name: spi_master_mock_tb
+// Project Name: simple-spi
+// Target Devices: Zybo Z7-20
+// Tool Versions:
+// Description: Testbench for mock SPI Master module. 
+//              It assumes FPGA internal clock of 125MHz and 26Mhz SPI Master clock.
+//
+// Dependencies: params.vh
+//
+// Revision:
+// Revision 0.01 - File Created
+// Additional Comments:
+//
+//////////////////////////////////////////////////////////////////////////////////
+`timescale 1ns/1ps
+`include "../include/params.vh"
+
+
+module spi_master_mock_tb (
+
+);
+
+    // Inputs
+    reg                            clk;
+    reg                            tx_enb;
+    reg  [`MASTER_FRAME_WIDTH-1:0] i_frame;
+    reg                            miso;
+
+    // Utils
+    reg [`CMD_BITS-1:0]            cmd_bits;
+    reg [`ADDR_BITS-1:0]           addr_bits;
+    reg [`PAYLOAD_BITS-1:0]        payload_bits;
+
+    // Outputs
+    wire                           cs;
+    wire                           sclk;
+    wire                           mosi;
+    wire [`BRIGHTNESS_WIDTH-1:0]   o_frame;
+
+    spi_master_mock uut (
+        .sysclk(clk),
+        .tx_enb(tx_enb),
+        .i_frame(i_frame),
+        .miso(miso),
+        .cs(cs),
+        .sclk(sclk),
+        .mosi(mosi),
+        .o_frame(o_frame)
+    );
+
+    initial begin
+        clk = 0;
+        forever #(`SLAVE_CLK_NS/2) clk = ~clk;
+    end
+
+    integer i;
+    initial begin
+        $dumpfile("spi_master_mock_tb_waveforms.vcd"); // Add waveform dumping
+        $dumpvars(0, spi_master_mock_tb.clk,
+                     spi_master_mock_tb.sclk,
+                     spi_master_mock_tb.cs,
+                     spi_master_mock_tb.tx_enb,
+                     spi_master_mock_tb.mosi,
+                     spi_master_mock_tb.i_frame,
+                     spi_master_mock_tb.miso,
+                     spi_master_mock_tb.o_frame);
+
+        // Initial conditions
+        tx_enb = 1'b0;
+        #(3 * `SLAVE_CLK_NS);
+
+        // Test 1: cs deasserted
+        if (cs == `CS_DEASSERT) begin
+            $display("Test 1: PASS- cs deasserted");
+        end else begin
+            $display("Test 1: FAIL- got: %b, expected: %b", cs, `CS_DEASSERT);
+        end
+
+        // Test 2: only transmission (MSB convention)
+        cmd_bits     = 8'b10000000;
+        addr_bits    = 8'b10100000;
+        payload_bits = 8'b11010000;
+        i_frame      = {cmd_bits, addr_bits, payload_bits};
+        tx_enb       = 1'b1;
+
+        $display("Command bits testting...");
+        #(`SLAVE_CLK_NS);
+        for (i = 0; i < `CMD_BITS; i = i + 1) begin
+            #(`MASTER_CLK_NS);
+            if (cs == `CS_ASSERT) begin
+                $display("Test 2.1.%d cs asserted PASS", i);
+            end else begin
+                $display("Test 2.1.%d FAIL- got: %b, expected: %b", i, cs, `CS_DEASSERT);
+            end
+            if (mosi == cmd_bits[(`CMD_BITS-1) - i]) begin
+                $display("Test 2.1.%d mosi correct: %b", i, mosi);
+            end else begin
+                $display("Test 2.1.%d mosi incorrect: %b, expected: %b", i, mosi, cmd_bits[(`CMD_BITS-1) - i]);
+            end
+        end
+
+        $display("Address bits testting...");
+        #(`SLAVE_CLK_NS);
+        for (i = 0; i < `ADDR_BITS; i = i + 1) begin
+            #(`MASTER_CLK_NS);
+            if (cs == `CS_ASSERT) begin
+                $display("Test 2.2.%d cs asserted PASS", i);
+            end else begin
+                $display("Test 2.2.%d FAIL- got: %b, expected: %b", i, cs, `CS_DEASSERT);
+            end
+            if (mosi == addr_bits[(`ADDR_BITS-1) - i]) begin
+                $display("Test 2.2.%d mosi correct: %b", i, mosi);
+            end else begin
+                $display("Test 2.2.%d mosi incorrect: %b, expected: %b", i, mosi, addr_bits[(`ADDR_BITS-1) - i]);
+            end
+        end
+
+        $display("Payload bits testting...");
+        #(`SLAVE_CLK_NS);
+        for (i = 0; i < `PAYLOAD_BITS; i = i + 1) begin
+            #(`MASTER_CLK_NS);
+            if (cs == `CS_ASSERT) begin
+                $display("Test 2.3.%d cs asserted PASS", i);
+            end else begin
+                $display("Test 2.3.%d FAIL- got: %b, expected: %b", i, cs, `CS_DEASSERT);
+            end
+            if (mosi == payload_bits[(`PAYLOAD_BITS-1) - i]) begin
+                $display("Test 2.3.%d mosi correct: %b", i, mosi);
+            end else begin
+                $display("Test 2.3.%d mosi incorrect: %b, expected: %b", i, mosi, payload_bits[(`PAYLOAD_BITS-1) - i]);
+            end
+        end
+
+        #(3 * `SLAVE_CLK_NS);
+        $finish;
+
+    end
+
+endmodule


### PR DESCRIPTION
Added spi master mock-up in Verilog which aims to emulate ESP32 SPI Master driver behavior. This module is simulation only and will be used to validate actually synthesizeable SPI slave 