### PR TITLE
Spi slave implementation- partially ok

### DIFF
--- a/src/hdl/spi_master_mock.v
+++ b/src/hdl/spi_master_mock.v
@@ -32,7 +32,10 @@ module spi_master_mock (
     output reg                            cs,          // chip select (active low)
     output wire                           sclk,        // clock signal issued to slave
     output reg                            mosi,        // serial master output
-    output wire [`BRIGHTNESS_WIDTH-1:0]   o_frame      // entire response
+    output wire [`BRIGHTNESS_WIDTH-1:0]   o_frame,     // entire response
+    output reg  [`MASTER_FRAME_WIDTH-1:0] o_m_shift_reg_debug,
+    output reg                            o_m_serial_debug,
+    output reg  [4:0]                     o_m_bit_rx_cnt_debug
 );
 
     // SPI Master FSM
@@ -51,7 +54,7 @@ module spi_master_mock (
     reg [`MASTER_FRAME_WIDTH-1:0] shift_reg_tx;        // transmit shift register
 
     // Master receiver
-    reg [2:0]                     bit_rx_cnt   = 0;
+    reg [4:0]                     bit_rx_cnt   = 0;
     reg [`MASTER_FRAME_WIDTH-1:0] shift_reg_rx = 0;    // receive shift register
 
     // 26MHz pulse generator
@@ -78,6 +81,7 @@ module spi_master_mock (
                 bit_frame_cnt    <= 0;
                 mosi             <= 1'b0;
                 shift_reg_tx     <= 0;
+                shift_reg_tx <= i_frame;
                 if (tx_enb == 1'b1) begin
                     shift_reg_tx <= i_frame;
                     cs           <= `CS_ASSERT;
@@ -86,7 +90,7 @@ module spi_master_mock (
             end
             COMMAND: begin
                 cs                <= `CS_ASSERT;
-                if (sclk_falling && bit_frame_cnt <= (`CMD_BITS - 1)) begin // sclk_int
+                if (sclk_falling && bit_frame_cnt < `CMD_BITS) begin
                     mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
                     shift_reg_tx  <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
                     bit_frame_cnt <= bit_frame_cnt + 1'b1;
@@ -97,7 +101,7 @@ module spi_master_mock (
             end
             ADDRESS: begin
                 cs                <= `CS_ASSERT;
-                if (sclk_falling && bit_frame_cnt <= (`ADDR_BITS - 1)) begin
+                if (sclk_falling && bit_frame_cnt < `ADDR_BITS) begin
                     mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
                     shift_reg_tx  <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
                     bit_frame_cnt <= bit_frame_cnt + 1'b1;
@@ -108,13 +112,17 @@ module spi_master_mock (
             end
             WRITE  : begin
                 cs                <= `CS_ASSERT;
-                if (sclk_falling && bit_frame_cnt <= (`PAYLOAD_BITS - 1)) begin
+                if (sclk_falling && bit_frame_cnt < `PAYLOAD_BITS) begin
                     mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
                     shift_reg_tx  <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
                     bit_frame_cnt <= bit_frame_cnt + 1'b1;
                 end else if (bit_frame_cnt == `PAYLOAD_BITS) begin
-                    bit_frame_cnt <= 0;
-                    curr_state    <= DONE;
+                    // in order to make sure that an entire transaction
+                    // has completed SPI master has to wait an extra sclk cycle
+                    if (sclk_rising) begin
+                        bit_frame_cnt <= 0;
+                        curr_state    <= DONE;
+                    end
                 end
             end
             DONE   : begin
@@ -130,12 +138,20 @@ module spi_master_mock (
 
     // Read process: triggered on the rising edge sclk_int
     always @(posedge sysclk) begin
-        if (sclk_rising && curr_state != IDLE && curr_state != DONE) begin // sclk_cnt == (`CLKS_PER_MASTER_SCLK - 1) && s
+        if (cs == `CS_DEASSERT) begin
+            shift_reg_rx <= 0;
+            bit_rx_cnt   <= 0;
+        end else begin
+        if (sclk_rising) begin //  && curr_state != IDLE && curr_state != DONE
+            o_m_serial_debug <= miso;
+            o_m_shift_reg_debug <= shift_reg_tx;
+            o_m_bit_rx_cnt_debug <= bit_rx_cnt;
             shift_reg_rx <= {shift_reg_rx[`MASTER_FRAME_WIDTH-2:0], miso};
             bit_rx_cnt   <= bit_rx_cnt + 1;
             if (bit_rx_cnt == `MASTER_FRAME_WIDTH - 1) begin
                 bit_rx_cnt <= 0;
             end
+        end
         end
     end
     assign o_frame = shift_reg_rx[6:0];

--- a/src/hdl/spi_master_mock.v
+++ b/src/hdl/spi_master_mock.v
@@ -55,17 +55,6 @@ module spi_master_mock (
     reg [`MASTER_FRAME_WIDTH-1:0] shift_reg_rx = 0;    // receive shift register
 
     // 26MHz pulse generator
-    /*
-    always @(posedge sysclk) begin
-        if (sclk_cnt == (`CLKS_PER_MASTER_SCLK - 1)) begin
-            sclk_int   <= 1'b1;
-            sclk_cnt   <= 0;
-        end else begin
-            sclk_int   <= 1'b0;
-            sclk_cnt   <= sclk_cnt + 1'b1;
-        end
-    end
-    */
     reg                           sclk_prev;
     always @(posedge sysclk) begin
         sclk_prev      <= sclk_int;

--- a/src/hdl/spi_master_mock.v
+++ b/src/hdl/spi_master_mock.v
@@ -46,7 +46,7 @@ module spi_master_mock (
     // Master transmitter + sclk generation
     reg [2:0]                     curr_state;
     reg [4:0]                     bit_frame_cnt;       // indexing what is the current bit from data frame to send
-    reg                           sclk_int;            // internal output master clock
+    reg                           sclk_int     = 1'b0; // internal output master clock
     reg [2:0]                     sclk_cnt     = 0;    // count cycles of 125Mhz frequency clock before issuing sclk pulse
     reg [`MASTER_FRAME_WIDTH-1:0] shift_reg_tx;        // transmit shift register
 
@@ -55,6 +55,7 @@ module spi_master_mock (
     reg [`MASTER_FRAME_WIDTH-1:0] shift_reg_rx = 0;    // receive shift register
 
     // 26MHz pulse generator
+    /*
     always @(posedge sysclk) begin
         if (sclk_cnt == (`CLKS_PER_MASTER_SCLK - 1)) begin
             sclk_int   <= 1'b1;
@@ -64,7 +65,21 @@ module spi_master_mock (
             sclk_cnt   <= sclk_cnt + 1'b1;
         end
     end
-    assign sclk     = sclk_int;
+    */
+    reg                           sclk_prev;
+    always @(posedge sysclk) begin
+        sclk_prev      <= sclk_int;
+        if (sclk_cnt == (`CLKS_PER_MASTER_SCLK - 1)) begin
+            sclk_int   <= ~sclk_int;
+            sclk_cnt   <= 0;
+        end else begin
+            sclk_int   <= sclk_int;
+            sclk_cnt   <= sclk_cnt + 1'b1;
+        end
+    end
+    wire   sclk_falling = sclk_prev  & ~sclk_int;
+    wire   sclk_rising  = ~sclk_prev & sclk_int;
+    assign sclk         = sclk_int;
 
     // Write process: triggered on the falling edge sclk_int
     always @(posedge sysclk) begin 
@@ -72,7 +87,7 @@ module spi_master_mock (
             IDLE   : begin
                 cs               <= `CS_DEASSERT;
                 bit_frame_cnt    <= 0;
-                mosi             <= 1'bx;
+                mosi             <= 1'b0;
                 shift_reg_tx     <= 0;
                 if (tx_enb == 1'b1) begin
                     shift_reg_tx <= i_frame;
@@ -82,7 +97,7 @@ module spi_master_mock (
             end
             COMMAND: begin
                 cs                <= `CS_ASSERT;
-                if (sclk_int && bit_frame_cnt <= (`CMD_BITS - 1)) begin
+                if (sclk_falling && bit_frame_cnt <= (`CMD_BITS - 1)) begin // sclk_int
                     mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
                     shift_reg_tx  <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
                     bit_frame_cnt <= bit_frame_cnt + 1'b1;
@@ -93,7 +108,7 @@ module spi_master_mock (
             end
             ADDRESS: begin
                 cs                <= `CS_ASSERT;
-                if (sclk_int && bit_frame_cnt <= (`ADDR_BITS - 1)) begin
+                if (sclk_falling && bit_frame_cnt <= (`ADDR_BITS - 1)) begin
                     mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
                     shift_reg_tx  <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
                     bit_frame_cnt <= bit_frame_cnt + 1'b1;
@@ -104,7 +119,7 @@ module spi_master_mock (
             end
             WRITE  : begin
                 cs                <= `CS_ASSERT;
-                if (sclk_int && bit_frame_cnt <= (`PAYLOAD_BITS - 1)) begin
+                if (sclk_falling && bit_frame_cnt <= (`PAYLOAD_BITS - 1)) begin
                     mosi          <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
                     shift_reg_tx  <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
                     bit_frame_cnt <= bit_frame_cnt + 1'b1;
@@ -115,7 +130,7 @@ module spi_master_mock (
             end
             DONE   : begin
                 cs            <= `CS_DEASSERT;
-                mosi          <= 1'bx;
+                // mosi          <= 1'b0; // latching on the very last bit
                 bit_frame_cnt <= 0;
                 shift_reg_tx  <= 0;
                 curr_state    <= IDLE;
@@ -126,7 +141,7 @@ module spi_master_mock (
 
     // Read process: triggered on the rising edge sclk_int
     always @(posedge sysclk) begin
-        if (sclk_cnt == (`CLKS_PER_MASTER_SCLK - 1) && !sclk_int && curr_state != IDLE && curr_state != DONE) begin
+        if (sclk_rising && curr_state != IDLE && curr_state != DONE) begin // sclk_cnt == (`CLKS_PER_MASTER_SCLK - 1) && s
             shift_reg_rx <= {shift_reg_rx[`MASTER_FRAME_WIDTH-2:0], miso};
             bit_rx_cnt   <= bit_rx_cnt + 1;
             if (bit_rx_cnt == `MASTER_FRAME_WIDTH - 1) begin

--- a/src/hdl/spi_slave.v
+++ b/src/hdl/spi_slave.v
@@ -11,6 +11,9 @@
 // Description: SPI Slave module. This module decodes incomming message to either:
 //              specify which LED to light up with a certain % of brightness or
 //              to send back information about brightness level of the LED.
+//              Module configured for SPI Mode 0.
+//              It assumes an internal 125MHz clock and an external provided via
+//              sclk input 26MHz one.
 //
 // Dependencies: params.vh
 //

--- a/src/hdl/spi_slave.v
+++ b/src/hdl/spi_slave.v
@@ -35,7 +35,7 @@ module spi_slave (
                                                        // send the data back
     input  wire [`MASTER_FRAME_WIDTH-1:0] i_slv_frame, // input data frame- created outside
                                                        // transmitting LED data back
-    output wire                           miso,
+    output reg                            miso,
     output reg  [`CMD_BITS-1:0]           o_cmd,
     output reg  [`ADDR_BITS-1:0]          o_addr,
     output reg  [`PAYLOAD_BITS-1:0]       o_payload
@@ -74,7 +74,7 @@ module spi_slave (
     wire sclk_falling = ~sclk_sync & sclk_prev; // detect sclk falling edge
 
     // Read process: triggered by cs active-low and sclk
-    @always (posedge sysclk) begin
+    always @(posedge sysclk) begin
         if (cs == `CS_ASSERT) begin
             case (curr_state)
                 IDLE   : begin
@@ -145,7 +145,7 @@ module spi_slave (
             slv_clk_cnt  <= 2'b0;
             o_cmd        <= `CMD_NOP;
             o_addr       <= `ADDR_NONE;
-            o_payload    <=  `PAYLOAD_NONE;
+            o_payload    <= `PAYLOAD_NONE;
             curr_state   <= IDLE;
         end
 

--- a/src/hdl/spi_slave.v
+++ b/src/hdl/spi_slave.v
@@ -1,0 +1,39 @@
+//////////////////////////////////////////////////////////////////////////////////
+// Company: ISAE
+// Engineer: Szymon Bogus
+//
+// Create Date: 28/07/2025
+// Design Name:
+// Module Name: spi_slave
+// Project Name: simple-spi
+// Target Devices: Zybo Z7-20
+// Tool Versions:
+// Description: SPI Slave module. This module decodes incomming message to either:
+//              specify which LED to light up with a certain % of brightness or
+//              to send back information about brightness level of the LED.
+//
+// Dependencies: params.vh
+//
+// Revision:
+// Revision 0.01 - File Created
+// Additional Comments: synthesizeable
+//
+//////////////////////////////////////////////////////////////////////////////////
+`timescale 1ns/1ps
+`include "../include/params.vh"
+
+
+module spi_slave (
+    input                               sysclk,
+    input  wire                         sclk,
+    input  wire                         cs,
+    input  wire                         mosi,
+    output wire                         miso,
+    output wire [`LED_ADDR_WIDTH-1:0]   o_led_addr,
+    output wire [`BRIGHTNESS_WIDTH-1:0] o_led_br_lvl,
+
+);
+
+
+
+endmodule

--- a/src/hdl/spi_slave.v
+++ b/src/hdl/spi_slave.v
@@ -31,10 +31,10 @@ module spi_slave (
     input  wire                           sclk,
     input  wire                           cs,
     input  wire                           mosi,
-    input  wire                           tx_enb,  // acitve high to indicate that slave can 
-                                                   // send the data back
-    input  wire [`MASTER_FRAME_WIDTH-1:0] i_frame, // input data frame- created outside
-                                                   // transmitting LED data back
+    input  wire                           slv_tx_enb,  // acitve high to indicate that slave can 
+                                                       // send the data back
+    input  wire [`MASTER_FRAME_WIDTH-1:0] i_slv_frame, // input data frame- created outside
+                                                       // transmitting LED data back
     output wire                           miso,
     output reg  [`CMD_BITS-1:0]           o_cmd,
     output reg  [`ADDR_BITS-1:0]          o_addr,
@@ -153,11 +153,11 @@ module spi_slave (
 
     // Write process: triggered on the falling edge of sclk
     always @(posedge sysclk) begin
-        shift_reg_tx <= (tx_enb == 1'b1) ? i_frame : 0;
+        shift_reg_tx <= (slv_tx_enb == 1'b1) ? i_slv_frame : 0;
     end
 
     always @(posedge sysclk) begin
-        if (sclk_falling && tx_enb == 1'b1 && cs == `CS_ASSERT && bit_tx_cnt < `MASTER_FRAME_WIDTH) begin
+        if (sclk_falling && slv_tx_enb == 1'b1 && cs == `CS_ASSERT && bit_tx_cnt < `MASTER_FRAME_WIDTH) begin
             miso         <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
             shift_reg_tx <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
             bit_tx_cnt   <= bit_tx_cnt + 1'b1;

--- a/src/hdl/spi_slave.v
+++ b/src/hdl/spi_slave.v
@@ -73,7 +73,7 @@ module spi_slave (
                     bit_rx_cnt   <= 0;
                     shift_reg_rx <= 0;
                     slv_clk_cnt  <= 2'b0;
-                    curr_state   <= COMMAND; // as cs is laready asserted next slave-clk cycle we can
+                    curr_state   <= COMMAND; // as cs is already asserted next slave-clk cycle we can
                                              // begin reading data bits
                 end
                 COMMAND: begin
@@ -120,7 +120,11 @@ module spi_slave (
                     end
                 end
                 DONE   : begin
-                    rx_dv <= 1'b1;
+                    rx_dv      <= 1'b1; // single clock cycle pulse
+                    o_cmd      <= shift_reg_rx[23:16];
+                    o_addr     <= shift_reg_rx[15:8];
+                    o_payload  <= shift_reg_rx[7:0];
+                    curr_state <= IDLE;
 
                 end
                 default: curr_state <= IDLE;
@@ -131,7 +135,8 @@ module spi_slave (
             shift_reg_rx <= 0;
             slv_clk_cnt  <= 2'b0;
             o_cmd        <= `CMD_NOP;
-            o_addr       <= `ADDR_NONE
+            o_addr       <= `ADDR_NONE;
+            o_payload    <=  `PAYLOAD_NONE;
             curr_state   <= IDLE;
         end
 

--- a/src/hdl/spi_slave.v
+++ b/src/hdl/spi_slave.v
@@ -32,11 +32,110 @@ module spi_slave (
     input  wire                         cs,
     input  wire                         mosi,
     output wire                         miso,
-    output wire [`LED_ADDR_WIDTH-1:0]   o_led_addr,
-    output wire [`BRIGHTNESS_WIDTH-1:0] o_led_br_lvl,
-
+    output reg  [`CMD_BITS-1:0]         o_cmd,
+    output reg  [`ADDR_BITS-1:0]        o_addr,
+    output reg  [`PAYLOAD_BITS-1:0]     o_payload
 );
 
+    // SPI Slave FSM
+    localparam                    IDLE       = 3'b000; // moves to COMMAND on cs set low
+    localparam                    COMMAND    = 3'b001;
+    localparam                    ADDRESS    = 3'b010;
+    localparam                    READ       = 3'b100;
+    // localparam                    WRITE      = 3'b110;
+    localparam                    DONE       = 3'b111;
+
+    // Slave receiver
+    reg                           rx_dv        = 1'b0; // high active when entire data frame is received
+    reg [2:0]                     curr_state;
+    reg [2:0]                     bit_rx_cnt   = 0;    // counts received bits to later on set high rx_dv
+    reg [`MASTER_FRAME_WIDTH-1:0] shift_reg_rx = 0;    // received bits are saved in the shift register
+    reg [1:0]                     slv_clk_cnt  = 2'b0; // counter of slvae-clock cycles until the middle of
+                                                       // the master-clock is acheived                
+
+    // sclk rising edge detector
+    reg sclk_prev;
+    reg sclk_sync;
+
+    always @(posedge sysclk) begin
+        sclk_prev <= sclk_sync;
+        sclk_sync <= sclk;                     // synchronize SCLK to 125 MHz domain
+    end
+
+    wire sclk_rising = sclk_sync & ~sclk_prev; // detect sclk rising edge
+
+    // Read process: triggered by cs active-low and sclk
+    @always (posedge sysclk) begin
+        if (cs == `CS_ASSERT) begin
+            case (curr_state)
+                IDLE   : begin
+                    rx_dv        <= 1'b0;
+                    bit_rx_cnt   <= 0;
+                    shift_reg_rx <= 0;
+                    slv_clk_cnt  <= 2'b0;
+                    curr_state   <= COMMAND; // as cs is laready asserted next slave-clk cycle we can
+                                             // begin reading data bits
+                end
+                COMMAND: begin
+                    rx_dv           <= 1'b0;
+                    if (sclk_rising && bit_rx_cnt < `CMD_BITS) begin
+                        // we are on the rising endge and now we will begin to count until the middle
+                        // of the rising part of the master-clock cycle for a stable data
+                        slv_clk_cnt <= slv_clk_cnt + 1'b1;
+                    end else if (sclk_sync && bit_rx_cnt < `CMD_BITS && slv_clk_cnt == 2'b10) begin
+                        // we are in the middle of the rising part of the master-clock cycle
+                        // now the data bit can be read
+                        shift_reg_rx <= {shift_reg_rx[`MASTER_FRAME_WIDTH-2:0], mosi};
+                        bit_rx_cnt   <= bit_rx_cnt + 1'b1;
+                        slv_clk_cnt  <= 2'b0;
+                    end else if (bit_rx_cnt == `CMD_BITS) begin
+                        bit_rx_cnt   <= 0;
+                        curr_state   <= ADDRESS;
+                    end
+                end
+                ADDRESS: begin
+                    rx_dv           <= 1'b0;
+                    if (sclk_rising && bit_rx_cnt < `ADDR_BITS) begin
+                        slv_clk_cnt <= slv_clk_cnt + 1'b1;
+                    end else if (sclk_sync && bit_rx_cnt < `ADDR_BITS && slv_clk_cnt == 2'b10) begin
+                        shift_reg_rx <= {shift_reg_rx[`MASTER_FRAME_WIDTH-2:0], mosi};
+                        bit_rx_cnt   <= bit_rx_cnt + 1'b1;
+                        slv_clk_cnt  <= 2'b0;
+                    end else if (bit_rx_cnt == `ADDR_BITS) begin
+                        bit_rx_cnt   <= 0;
+                        curr_state   <= READ;
+                    end
+                end
+                READ  : begin
+                    rx_dv           <= 1'b0;
+                    if (sclk_rising && bit_rx_cnt < `PAYLOAD_BITS) begin
+                        slv_clk_cnt <= slv_clk_cnt + 1'b1;
+                    end else if (sclk_sync && bit_rx_cnt < `PAYLOAD_BITS && slv_clk_cnt == 2'b10) begin
+                        shift_reg_rx <= {shift_reg_rx[`MASTER_FRAME_WIDTH-2:0], mosi};
+                        bit_rx_cnt   <= bit_rx_cnt + 1'b1;
+                        slv_clk_cnt  <= 2'b0;
+                    end else if (bit_rx_cnt == `PAYLOAD_BITS) begin
+                        bit_rx_cnt   <= 0;
+                        curr_state   <= DONE;
+                    end
+                end
+                DONE   : begin
+                    rx_dv <= 1'b1;
+
+                end
+                default: curr_state <= IDLE;
+            endcase
+        end else begin
+            rx_dv        <= 1'b0;
+            bit_rx_cnt   <= 0;
+            shift_reg_rx <= 0;
+            slv_clk_cnt  <= 2'b0;
+            o_cmd        <= `CMD_NOP;
+            o_addr       <= `ADDR_NONE
+            curr_state   <= IDLE;
+        end
+
+    end
 
 
 endmodule

--- a/src/hdl/spi_slave.v
+++ b/src/hdl/spi_slave.v
@@ -27,184 +27,163 @@
 
 
 module spi_slave (
-    input                                 sysclk,
-    input  wire                           sclk,
-    input  wire                           cs,
-    input  wire                           mosi,
-    input  wire                           slv_tx_enb,  // acitve high to indicate that slave can 
-                                                       // send the data back
-    input  wire [`MASTER_FRAME_WIDTH-1:0] i_slv_frame, // input data frame- created outside
-                                                       // transmitting LED data back
-    output reg                            miso,
-    output reg  [`CMD_BITS-1:0]           o_cmd,
-    output reg  [`ADDR_BITS-1:0]          o_addr,
-    output reg  [`PAYLOAD_BITS-1:0]       o_payload,
-    output reg  [`MASTER_FRAME_WIDTH-1:0] o_shift_reg_debug,
-    output reg                            o_serial_debug,
-    output reg  [3:0]                     o_bit_rx_cnt_debug,
-    output reg  [3:0]                     o_debug_stage
+    input                                  sysclk,
+    input  wire                            sclk,
+    input  wire                            cs,
+    input  wire                            mosi,
+    input  wire                            slv_tx_enb,
+    input  wire  [`MASTER_FRAME_WIDTH-1:0] i_slv_frame,
+    output reg                             miso,
+    output wire  [`CMD_BITS-1:0]           o_cmd,
+    output wire  [`ADDR_BITS-1:0]          o_addr,
+    output wire  [`PAYLOAD_BITS-1:0]       o_payload,
+    output wire                            rx_dv,
+    output reg   [`MASTER_FRAME_WIDTH-1:0] o_shift_reg_debug,
+    output reg                             o_serial_debug,
+    output reg   [3:0]                     o_bit_rx_cnt_debug,
+    output reg   [3:0]                     o_debug_stage
 );
 
     // SPI Slave FSM
-    localparam                    IDLE       = 3'b000; // moves to WAIT on cs set low
-    localparam                    WAIT       = 3'b011; // waits for first sclk rising edge
-    localparam                    COMMAND    = 3'b001;
-    localparam                    ADDRESS    = 3'b010;
-    localparam                    READ       = 3'b100;
-    // localparam                    WRITE      = 3'b110;
-    localparam                    DONE       = 3'b111;
+    localparam IDLE    = 3'b000;
+    localparam COMMAND = 3'b001;
+    localparam ADDRESS = 3'b010;
+    localparam WRITE   = 3'b011;
+    localparam DONE    = 3'b111;
 
     // Slave receiver
-    reg                           rx_dv        = 1'b0; // high active when entire data frame is received
-    reg [2:0]                     curr_state;
-    reg [3:0]                     bit_rx_cnt   = 0;    // counts received bits to later on set high rx_dv
-    reg [`MASTER_FRAME_WIDTH-1:0] shift_reg_rx = 0;    // received bits are saved in the shift register
-    reg [1:0]                     slv_clk_cnt  = 2'b0; // counter of slvae-clock cycles until the middle of
-                                                       // the master-clock is acheived                
-
-    reg [1:0]                     wait_cnt     = 2'b0;
+    reg [2:0]                     curr_state      = IDLE;
+    reg [4:0]                     bit_rx_cnt      = 0;
+    reg [`MASTER_FRAME_WIDTH-1:0] shift_reg_rx    = 0;
+    reg                           first_edge_seen = 0;  // Flag to track first SCLK edge
 
     // Slave transmitter
-    reg [4:0]                     bit_tx_cnt   = 0;
+    reg [4:0]                     bit_tx_cnt = 0;
     reg [`MASTER_FRAME_WIDTH-1:0] shift_reg_tx = 0;
 
-    // sclk rising/falling edge detectors
-    reg sclk_prev;
-    reg sclk_sync;
-
+    // Clock edge detection with proper synchronization
+    reg [2:0]                     sclk_sync = 3'b000;
+    
     always @(posedge sysclk) begin
-        sclk_prev <= sclk_sync;
-        sclk_sync <= sclk;                      // synchronize SCLK to 125 MHz domain
+        sclk_sync <= {sclk_sync[1:0], sclk};
     end
+    
+    wire                           sclk_rising  = (sclk_sync[2:1] == 2'b01);
+    wire                           sclk_falling = (sclk_sync[2:1] == 2'b10);
 
-    wire sclk_rising  = sclk_sync & ~sclk_prev; // detect sclk rising edge
-    wire sclk_falling = ~sclk_sync & sclk_prev; // detect sclk falling edge
-
-    // Read process: triggered by cs active-low and sclk
+    // CS edge detection
+    reg [2:0]                      cs_sync = 3'b111;
     always @(posedge sysclk) begin
-        if (cs == `CS_DEASSERT && curr_state != READ) begin
-            rx_dv        <= 1'b0;
-            bit_rx_cnt   <= 0;
-            shift_reg_rx <= 0;
-            slv_clk_cnt  <= 2'b0;
-            o_cmd        <= `CMD_NOP;
-            o_addr       <= `ADDR_NONE;
-            o_payload    <= `PAYLOAD_NONE;
-            curr_state   <= IDLE;
-            o_shift_reg_debug <= shift_reg_rx;
-            o_serial_debug    <= mosi;
-        end else if (cs == `CS_DEASSERT && curr_state == READ) begin
-            curr_state <= READ; // tried to prevent FSM from resetting while finishing trnasaction
-                                // but it doesn't work
-        end else begin
-            o_debug_stage  <= curr_state;
-            o_bit_rx_cnt_debug <= bit_rx_cnt;
+        cs_sync <= {cs_sync[1:0], cs};
+    end
+    
+    wire                           cs_falling = (cs_sync[2:1] == 2'b10);
+
+    // Main FSM for receiving data
+    always @(posedge sysclk) begin
+        if (cs_sync[1] == `CS_DEASSERT) begin
+            curr_state      <= IDLE;
+            bit_rx_cnt      <= 0;
+            first_edge_seen <= 0;
+        end
+        else begin
+            // debug outputs
+            o_debug_stage      <= curr_state;
+            o_bit_rx_cnt_debug <= bit_rx_cnt[3:0];
+            o_shift_reg_debug  <= shift_reg_rx;
+            o_serial_debug     <= mosi;
+            
             case (curr_state)
                 IDLE   : begin
-                    rx_dv        <= 1'b0;
-                    bit_rx_cnt   <= 0;
-                    shift_reg_rx <= 0;
-                    slv_clk_cnt  <= 2'b0;
-                    wait_cnt     <= 2'b0;
-                    curr_state   <= WAIT; // added to synchronize with mosi
-                    o_shift_reg_debug <= shift_reg_rx;
-                    o_serial_debug    <= mosi;
-                end
-                
-                WAIT   : begin
-                    rx_dv <= 1'b0;
-                    bit_rx_cnt   <= 0;
-                    shift_reg_rx <= 0;
-                    slv_clk_cnt  <= 2'b0;
-                    o_shift_reg_debug <= shift_reg_rx;
-                    o_serial_debug    <= mosi;
-                    if (sclk_rising) begin // wait for first sclk rising edge after CS low
-                        curr_state <= COMMAND;
+                    if (cs_falling) begin
+                        curr_state      <= COMMAND;
+                        bit_rx_cnt      <= 0;
+                        first_edge_seen <= 0;
+                        shift_reg_rx    <= 0; // reset shift register when starting new transaction
                     end
                 end
                 
                 COMMAND: begin
-                    rx_dv           <= 1'b0;
-                    if (sclk_rising && bit_rx_cnt < `CMD_BITS) begin
-                        slv_clk_cnt <= slv_clk_cnt + 1;
-                    end else if (sclk_sync && slv_clk_cnt < `SLV_WAIT_CLK_C && bit_rx_cnt < `CMD_BITS) begin
-                        slv_clk_cnt <= slv_clk_cnt + 1;
-                    end else if (sclk_sync && slv_clk_cnt == `SLV_WAIT_CLK_C && bit_rx_cnt < `CMD_BITS) begin
-                        shift_reg_rx <= {shift_reg_rx[`MASTER_FRAME_WIDTH-2:0], mosi};
-                        bit_rx_cnt <= bit_rx_cnt + 1;
-                        slv_clk_cnt <= 0;
-                        o_shift_reg_debug <= shift_reg_rx;
-                        o_serial_debug    <= mosi;
-                    end else if (bit_rx_cnt == `CMD_BITS) begin
-                        bit_rx_cnt <= 0;
+                    if (sclk_rising) begin
+                        if (!first_edge_seen) begin
+                            // skip the very first SCLK rising edge - master hasn't set up data yet
+                            first_edge_seen <= 1;
+                        end else begin
+                            shift_reg_rx    <= {shift_reg_rx[`MASTER_FRAME_WIDTH-2:0], mosi};
+                            bit_rx_cnt      <= bit_rx_cnt + 1;
+                        end
+                    end
+
+                    if (bit_rx_cnt == `CMD_BITS) begin
                         curr_state <= ADDRESS;
+                        bit_rx_cnt <= 0;
                     end
                 end
+                
                 ADDRESS: begin
-                    rx_dv           <= 1'b0;
-                    if (sclk_rising && bit_rx_cnt < `ADDR_BITS) begin
-                        slv_clk_cnt <= slv_clk_cnt + 1;
-                    end else if (sclk_sync && slv_clk_cnt < `SLV_WAIT_CLK_C && bit_rx_cnt < `ADDR_BITS) begin
-                        slv_clk_cnt <= slv_clk_cnt + 1;
-                    end else if (sclk_sync && slv_clk_cnt == `SLV_WAIT_CLK_C && bit_rx_cnt < `ADDR_BITS) begin
+                    if (sclk_rising) begin
                         shift_reg_rx <= {shift_reg_rx[`MASTER_FRAME_WIDTH-2:0], mosi};
-                        bit_rx_cnt <= bit_rx_cnt + 1;
-                        slv_clk_cnt <= 0;
-                        o_shift_reg_debug <= shift_reg_rx;
-                        o_serial_debug    <= mosi;
-                    end else if (bit_rx_cnt == `ADDR_BITS) begin
+                        bit_rx_cnt   <= bit_rx_cnt + 1;
+                    end
+
+                    if (bit_rx_cnt == `ADDR_BITS) begin
+                        curr_state <= WRITE;
                         bit_rx_cnt <= 0;
-                        curr_state <= READ;
                     end
                 end
-                READ  : begin
-                    rx_dv           <= 1'b0;
-                    if (sclk_rising && bit_rx_cnt < `PAYLOAD_BITS) begin
-                        slv_clk_cnt <= slv_clk_cnt + 1;
-                    end else if (sclk_sync && slv_clk_cnt < `SLV_WAIT_CLK_C && bit_rx_cnt < `PAYLOAD_BITS) begin
-                        slv_clk_cnt <= slv_clk_cnt + 1;
-                    end else if (sclk_sync && slv_clk_cnt == `SLV_WAIT_CLK_C && bit_rx_cnt < `PAYLOAD_BITS) begin
+                
+                WRITE  : begin
+                    if (sclk_rising) begin
                         shift_reg_rx <= {shift_reg_rx[`MASTER_FRAME_WIDTH-2:0], mosi};
-                        bit_rx_cnt <= bit_rx_cnt + 1;
-                        slv_clk_cnt <= 0;
-                        o_shift_reg_debug <= shift_reg_rx;
-                        o_serial_debug    <= mosi;
-                    end else if (bit_rx_cnt == `PAYLOAD_BITS) begin
-                        // shift_reg_rx <= shift_reg_rx << 1'b1;
-                        bit_rx_cnt <= 0;
+                        bit_rx_cnt   <= bit_rx_cnt + 1;
+                    end
+                     
+                    if (bit_rx_cnt == `PAYLOAD_BITS) begin
                         curr_state <= DONE;
+                        bit_rx_cnt <= 0;
                     end
                 end
+                
                 DONE   : begin
-                    rx_dv      <= 1'b1; // single clock cycle pulse
-                    o_cmd      <= shift_reg_rx[23:16];
-                    o_addr     <= shift_reg_rx[15:8];
-                    o_payload  <= shift_reg_rx[7:0];
                     curr_state <= IDLE;
-                    o_shift_reg_debug <= shift_reg_rx;
-                    o_serial_debug    <= mosi;
                 end
-                default: curr_state <= IDLE;
+                
+                default: begin
+                    curr_state <= IDLE;
+                end
             endcase
         end
-
     end
 
-    // Write process: triggered on the falling edge of sclk
-    always @(posedge sysclk) begin
-        shift_reg_tx <= (slv_tx_enb == 1'b1) ? i_slv_frame : 0;
-    end
+    // output assignments - data is valid when CS is deasserted (rx_dv high)
+    assign rx_dv     = (cs_sync[1] == `CS_DEASSERT) ? 1'b1                : 1'b0;
+    assign o_cmd     = (rx_dv == 1'b1)              ? shift_reg_rx[23:16] : `CMD_NOP;
+    assign o_addr    = (rx_dv == 1'b1)              ? shift_reg_rx[15:8]  : `ADDR_NONE;
+    assign o_payload = (rx_dv == 1'b1)              ? shift_reg_rx[7:0]   : `PAYLOAD_NONE;
 
+    // transmit logic - setup data on falling edge of SCLK (SPI Mode 0)
     always @(posedge sysclk) begin
-        if (sclk_falling && slv_tx_enb == 1'b1 && cs == `CS_ASSERT && bit_tx_cnt < `MASTER_FRAME_WIDTH) begin
-            miso         <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
-            shift_reg_tx <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
-            bit_tx_cnt   <= bit_tx_cnt + 1'b1;
-        end else if (cs == `CS_DEASSERT || bit_tx_cnt == `MASTER_FRAME_WIDTH) begin
-            miso         <= 1'b0;
+        if (cs_sync[1] == `CS_DEASSERT) begin
+            miso <= 1'b0;
+            bit_tx_cnt <= 0;
             shift_reg_tx <= 0;
         end
+        else if (slv_tx_enb) begin
+            // Load transmit data when enabled
+            if (bit_tx_cnt == 0 && !sclk_falling) begin
+                shift_reg_tx <= i_slv_frame;
+            end
+            
+            // Shift data out on falling edge of SCLK
+            if (sclk_falling && bit_tx_cnt < `MASTER_FRAME_WIDTH) begin
+                miso <= shift_reg_tx[`MASTER_FRAME_WIDTH - 1];
+                shift_reg_tx <= {shift_reg_tx[`MASTER_FRAME_WIDTH-2:0], 1'b0};
+                bit_tx_cnt <= bit_tx_cnt + 1;
+            end
+        end
+        else begin
+            miso <= 1'b0;
+        end
     end
-
 
 endmodule

--- a/src/hdl/spi_slave.v
+++ b/src/hdl/spi_slave.v
@@ -87,7 +87,7 @@ module spi_slave (
                 end
                 COMMAND: begin
                     rx_dv           <= 1'b0;
-                    if (sclk_rising && bit_rx_cnt < `CMD_BITS) begin
+                    if (sclk_rising && bit_rx_cnt < `CMD_BITS && slv_clk_cnt < 2'b10) begin
                         // we are on the rising endge and now we will begin to count until the middle
                         // of the rising part of the master-clock cycle for a stable data
                         slv_clk_cnt <= slv_clk_cnt + 1'b1;
@@ -104,7 +104,7 @@ module spi_slave (
                 end
                 ADDRESS: begin
                     rx_dv           <= 1'b0;
-                    if (sclk_rising && bit_rx_cnt < `ADDR_BITS) begin
+                    if (sclk_rising && bit_rx_cnt < `ADDR_BITS && slv_clk_cnt < 2'b10) begin
                         slv_clk_cnt <= slv_clk_cnt + 1'b1;
                     end else if (sclk_sync && bit_rx_cnt < `ADDR_BITS && slv_clk_cnt == 2'b10) begin
                         shift_reg_rx <= {shift_reg_rx[`MASTER_FRAME_WIDTH-2:0], mosi};
@@ -117,7 +117,7 @@ module spi_slave (
                 end
                 READ  : begin
                     rx_dv           <= 1'b0;
-                    if (sclk_rising && bit_rx_cnt < `PAYLOAD_BITS) begin
+                    if (sclk_rising && bit_rx_cnt < `PAYLOAD_BITS && slv_clk_cnt < 2'b10) begin
                         slv_clk_cnt <= slv_clk_cnt + 1'b1;
                     end else if (sclk_sync && bit_rx_cnt < `PAYLOAD_BITS && slv_clk_cnt == 2'b10) begin
                         shift_reg_rx <= {shift_reg_rx[`MASTER_FRAME_WIDTH-2:0], mosi};

--- a/src/include/params.vh
+++ b/src/include/params.vh
@@ -20,6 +20,8 @@
 `define CMD_NOP              8'h0
 // ADDR
 `define ADDR_NONE            8'hD
+// PAYLOAD
+`define PAYLOAD_NONE         8'h0;
 
 
 // SPI Master data frame is 24 bits wide and each section: command, address, payload

--- a/src/include/params.vh
+++ b/src/include/params.vh
@@ -31,6 +31,10 @@
 `define ADDR_BITS            8 // first 4 bits matter
 `define PAYLOAD_BITS         8 // first 7 bits matter | corresponds to payload of both master and slave
 
+// SPI slave
+`define SLV_WAIT_CLK_C       3 // number of SPI slave clock ycles to wait when the master clock is already
+                               // before sampling mosi bit- aded to avoid metastability
+
 // CS
 `define CS_ASSERT            1'b0
 `define CS_DEASSERT          1'b1

--- a/src/include/params.vh
+++ b/src/include/params.vh
@@ -5,6 +5,7 @@
 `define BRIGHTNESS_WIDTH     7    // brightness level can vary: 0%-100%; 7-bit number required to store the input value
 `define LED_MIN_BRIGHTNESS   0    // minimal level of brightness in %- min. duty cycle
 `define LED_MAX_BRIGHTNESS   90   // maximal level of brightness in %- max. duty cycle
+`define LED_ADDR_WIDTH       4    // 13 addressable LEDs with 4-bit long addresses
 
 // SPI
 // SPI data frame

--- a/src/include/params.vh
+++ b/src/include/params.vh
@@ -21,7 +21,7 @@
 // ADDR
 `define ADDR_NONE            8'hD
 // PAYLOAD
-`define PAYLOAD_NONE         8'h0;
+`define PAYLOAD_NONE         8'h0
 
 
 // SPI Master data frame is 24 bits wide and each section: command, address, payload

--- a/src/include/params.vh
+++ b/src/include/params.vh
@@ -13,6 +13,15 @@
 `define CLKS_PER_MASTER_SCLK 5    // FPGA has 125Mhz clock but ESP32 SPI Master has 26MHz, this parameter specifies how many 
                                   // 125Mhz frequency clock cycles to wait before issuing 25Mhz pulse
 
+// Master data frame enconding
+// CMD
+`define CMD_LED_SET          8'h1
+`define CMD_LED_READ         8'h2
+`define CMD_NOP              8'h0
+// ADDR
+`define ADDR_NONE            8'hD
+
+
 // SPI Master data frame is 24 bits wide and each section: command, address, payload
 // is equally 8 bits wide, however, when the data for a section isn't encoded with 8 bits
 // but with n-bits then first n-bits are important and the rest is garbage

--- a/src/include/params.vh
+++ b/src/include/params.vh
@@ -31,10 +31,6 @@
 `define ADDR_BITS            8 // first 4 bits matter
 `define PAYLOAD_BITS         8 // first 7 bits matter | corresponds to payload of both master and slave
 
-// SPI slave
-`define SLV_WAIT_CLK_C       3 // number of SPI slave clock ycles to wait when the master clock is already
-                               // before sampling mosi bit- aded to avoid metastability
-
 // CS
 `define CS_ASSERT            1'b0
 `define CS_DEASSERT          1'b1

--- a/src/sim/spi_master_mock_tb.v
+++ b/src/sim/spi_master_mock_tb.v
@@ -101,7 +101,7 @@ module spi_master_mock_tb (
         #(`SLAVE_CLK_NS);
         for (i = 0; i < `CMD_BITS; i = i + 1) begin
             @(negedge sclk) begin
-                #(4 * `SLAVE_CLK_NS);
+                #20;
                 rx_cmd_bits[`CMD_BITS - 1 - i] = mosi;
             end
         end
@@ -115,7 +115,7 @@ module spi_master_mock_tb (
         #(`SLAVE_CLK_NS);
         for (i = 0; i < `ADDR_BITS; i = i + 1) begin
             @(negedge sclk) begin
-                #(4 * `SLAVE_CLK_NS);
+                #20;
                 rx_addr_bits[`ADDR_BITS - 1 - i] = mosi;
             end
         end
@@ -129,7 +129,7 @@ module spi_master_mock_tb (
         #(`SLAVE_CLK_NS);
         for (i = 0; i < `PAYLOAD_BITS; i = i + 1) begin
             @(negedge sclk) begin
-                #(4 * `SLAVE_CLK_NS);
+                #20;
                 rx_payload_bits[`PAYLOAD_BITS - 1 - i] = mosi;
             end
         end
@@ -157,13 +157,12 @@ module spi_master_mock_tb (
         $display("Command bits testting...");
         #(`SLAVE_CLK_NS);
         for (i = 0; i < `CMD_BITS; i = i + 1) begin
-            @(posedge sclk) begin
-                #(2 * `SLAVE_CLK_NS);
-                miso = slave_data_frame[j];
-            end
             @(negedge sclk) begin
-                #(4 * `SLAVE_CLK_NS);
+                #20;
                 rx_cmd_bits[`CMD_BITS - 1 - i] = mosi;
+            end
+            @(posedge sclk) begin
+                miso = slave_data_frame[j];
             end
             j = j - 1;
         end
@@ -176,13 +175,12 @@ module spi_master_mock_tb (
         $display("Address bits testting...");
         #(`SLAVE_CLK_NS);
         for (i = 0; i < `ADDR_BITS; i = i + 1) begin
-            @(posedge sclk) begin
-                #(2 * `SLAVE_CLK_NS);
-                miso = slave_data_frame[j];
-            end
             @(negedge sclk) begin
-                #(4 * `SLAVE_CLK_NS);
+                #20;
                 rx_addr_bits[`ADDR_BITS - 1 - i] = mosi;
+            end
+            @(posedge sclk) begin
+                miso = slave_data_frame[j];
             end
             j = j - 1;
         end
@@ -195,13 +193,12 @@ module spi_master_mock_tb (
         $display("Payload bits testting...");
         #(`SLAVE_CLK_NS);
         for (i = 0; i < `PAYLOAD_BITS; i = i + 1) begin
-            @(posedge sclk) begin
-                #(2 * `SLAVE_CLK_NS);
-                miso = slave_data_frame[j];
-            end
             @(negedge sclk) begin
-                #(4 * `SLAVE_CLK_NS);
+                #20;
                 rx_payload_bits[`PAYLOAD_BITS - 1 - i] = mosi;
+            end
+            @(posedge sclk) begin
+                miso = slave_data_frame[j];
             end
             j = j - 1;
         end

--- a/src/sim/spi_slave_tb.v
+++ b/src/sim/spi_slave_tb.v
@@ -105,9 +105,9 @@ module spi_slave_tb (
         #(3 * `SLAVE_CLK_NS);
 
         // Test 1: master transmission only (set LED 2 to 10% brightness)
-        mock_master_cmd_bits     = `CMD_LED_SET;
-        mock_master_addr_bits    = 8'h2;
-        mock_master_payload_bits = 8'hA;
+        mock_master_cmd_bits     = 8'b10000000;
+        mock_master_addr_bits    = 8'b10100000;
+        mock_master_payload_bits = 8'b11010000;
         i_frame                  = {mock_master_cmd_bits, 
                                     mock_master_addr_bits, 
                                     mock_master_payload_bits};

--- a/src/sim/spi_slave_tb.v
+++ b/src/sim/spi_slave_tb.v
@@ -58,7 +58,87 @@ module spi_slave_tb (
     reg  [`ADDR_BITS-1:0]           mock_slave_addr_bits;
     reg  [`PAYLOAD_BITS-1:0]        mock_slave_payload_bits;
 
+    spi_master_mock spi_master_uut (
+        .sysclk(clk),
+        .tx_enb(tx_enb),
+        .i_frame(i_frame),
+        .miso(miso),
+        .cs(cs),
+        .sclk(sclk),
+        .mosi(mosi),
+        .o_frame(o_frame)
+    );
 
+    spi_slave spi_slave_uut (
+        .sysclk(clk),
+        .sclk(sclk),
+        .cs(cs),
+        .mosi(mosi),
+        .slv_tx_enb(slv_tx_enb),
+        .i_slv_frame(i_slv_frame),
+        .miso(miso),
+        .o_cmd(o_cmd),
+        .o_addr(o_addr),
+        .o_payload(o_payload)
+    );
+
+    initial begin
+        clk = 0;
+        forever #(`SLAVE_CLK_NS/2) clk = ~clk;
+    end
+
+    integer i;
+    initial begin
+        $dumpfile("spi_slave_tb_waveforms.vcd");
+        $dumpvars(0, spi_slave_tb.clk,
+                     spi_slave_tb.sclk,
+                     spi_slave_tb.cs,
+                     spi_slave_tb.miso,
+                     spi_slave_tb.mosi,
+                     spi_slave_tb.o_cmd,
+                     spi_slave_tb.o_addr,
+                     spi_slave_tb.o_payload);
+
+        // Initial conditions
+        tx_enb     = 1'b0;
+        slv_tx_enb = 1'b0;
+        #(3 * `SLAVE_CLK_NS);
+
+        // Test 1: master transmission only (set LED 2 to 10% brightness)
+        mock_master_cmd_bits     = `CMD_LED_SET;
+        mock_master_addr_bits    = 8'h2;
+        mock_master_payload_bits = 8'hA;
+        i_frame                  = {mock_master_cmd_bits, 
+                                    mock_master_addr_bits, 
+                                    mock_master_payload_bits};
+        tx_enb                   = 1'b1;
+
+        $display("Master sending...");
+        #(`SLAVE_CLK_NS);
+        for (i = 0; i < `MASTER_FRAME_WIDTH; i = i + 1) begin
+            #(`MASTER_CLK_NS);
+        end
+        #(`SLAVE_CLK_NS);
+        if (o_cmd == mock_master_cmd_bits) begin
+            $display("Test 1.1: PASS- command bits received correctly");
+        end else begin
+            $display("Test 1.1: FAIL- got: %b, expected: %b cmd", o_cmd, mock_master_cmd_bits);
+        end
+        if (o_addr == mock_master_addr_bits) begin
+            $display("Test 1.2: PASS- address bits received correctly");
+        end else begin
+            $display("Test 1.2: FAIL- got: %b, expected: %b addr", o_addr, mock_master_addr_bits);
+        end
+        if (o_payload == mock_master_payload_bits) begin
+            $display("Test 1.3: PASS- payload bits received correctly");
+        end else begin
+            $display("Test 1.1: FAIL- got: %b, expected: %b data", o_payload, mock_master_payload_bits);
+        end
+
+        #(3 * `SLAVE_CLK_NS);
+        $finish;
+
+    end
 
 
 endmodule

--- a/src/sim/spi_slave_tb.v
+++ b/src/sim/spi_slave_tb.v
@@ -20,3 +20,45 @@
 //////////////////////////////////////////////////////////////////////////////////
 `timescale 1ns/1ps
 `include "../include/params.vh"
+
+
+module spi_slave_tb (
+
+);
+
+    // Inputs: master&slave
+    reg                             clk;
+    
+    // Inputs: master
+    reg                             tx_enb;
+    reg  [`MASTER_FRAME_WIDTH-1:0]  i_frame;
+    wire                            miso; // output for slave
+
+    // Outputs: master -> inputs: slave
+    wire                            cs;
+    wire                            sclk;
+    wire                            mosi;
+    wire                            o_frame;
+
+    // Inputs: slave
+    reg                             slv_tx_enb;
+    reg  [`MASTER_FRAME_WIDTH-1:0]  i_slv_frame;
+
+    // Outputs: slave (everything except of miso)
+    wire [`CMD_BITS-1:0]            o_cmd;
+    wire [`ADDR_BITS-1:0]           o_addr;
+    wire [`PAYLOAD_BITS-1:0]        o_payload;
+
+    // Utils: used to instantiate master i_frame
+    reg  [`CMD_BITS-1:0]            mock_master_cmd_bits;
+    reg  [`ADDR_BITS-1:0]           mock_master_addr_bits;
+    reg  [`PAYLOAD_BITS-1:0]        mock_master_payload_bits;
+    // used for slave i_slv_frame
+    reg  [`CMD_BITS-1:0]            mock_slave_cmd_bits;
+    reg  [`ADDR_BITS-1:0]           mock_slave_addr_bits;
+    reg  [`PAYLOAD_BITS-1:0]        mock_slave_payload_bits;
+
+
+
+
+endmodule

--- a/src/sim/spi_slave_tb.v
+++ b/src/sim/spi_slave_tb.v
@@ -1,0 +1,22 @@
+//////////////////////////////////////////////////////////////////////////////////
+// Company: ISAE
+// Engineer: Szymon Bogus
+//
+// Create Date: 08/08/2025
+// Design Name:
+// Module Name: spi_slave_tb
+// Project Name: simple-spi
+// Target Devices: Zybo Z7-20
+// Tool Versions:
+// Description: Testbench for mock SPI Slave module. 
+//              It assumes FPGA internal clock of 125MHz and 26Mhz SPI Master clock.
+//
+// Dependencies: params.vh
+//
+// Revision:
+// Revision 0.01 - File Created
+// Additional Comments:
+//
+//////////////////////////////////////////////////////////////////////////////////
+`timescale 1ns/1ps
+`include "../include/params.vh"


### PR DESCRIPTION
It's partially ok because onyl single testbenches are passing. When Two consecutive tests are run old master data frame is transmitted. I couldn't fix it so far properly but I'm willing to test if that maybe only simulation issue